### PR TITLE
Add deps to devcontainer to convert and preview PDF

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "uv sync",
+	"postCreateCommand": "uv sync && sudo apt-get update -y -qq && sudo apt-get install -y libreoffice",
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
@@ -25,8 +25,8 @@
 				"tamasfe.even-better-toml",
 				"ms-toolsai.jupyter",
 				"quarto.quarto",
-				"nanxstats.textmate-rstheme",
-				"syncfusioninc.document-viewer-vscode-extensions"
+				"James-Yu.latex-workshop",
+				"nanxstats.textmate-rstheme"
 			],
 			"settings": {
 				"editor.fontSize": 20,


### PR DESCRIPTION
Similar to https://github.com/nanxstats/pycsr/pull/60

This PR adds these dependencies to the devcontainer, to support PDF related functionalities:

- LibreOffice for converting RTF to PDF. In case any conversion step is added, this is needed by rtflite.
- VS Code extension [Latex Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) (4M+ downloads, MIT license) for previewing PDF files.

Note that the `texlive` dependencies are not added because the Quarto book only has HTML output type specified.

Now you can run `quarto render` to build the entire book from source within the browser using GitHub Codespaces.